### PR TITLE
pref:herokuへのpush時にエラーが出たため、map-show.jsのテンプレート構文による文字列中での変数展開を従前の書き方へ修正

### DIFF
--- a/app/assets/javascripts/map-show.js
+++ b/app/assets/javascripts/map-show.js
@@ -27,7 +27,7 @@ function initMap() {
       //取得した座標の生成
       var latlng = new google.maps.LatLng(results[0].geometry.location.lat(), results[0].geometry.location.lng());
       //情報ウィンドウに表示するコンテンツを作成
-      var content = `<div id="map_content"><p>${title}<br/>${address}<br/><a href="https://maps.google.co.jp/maps?q=${latlng}&iwloc=J" target="_blank" rel="noopener noreferrer">Googleマップで見る</a></p></div>`;
+      var content = '<div id="map_content"><p>' + title + '<br/>' + address + '<br/><a href="https://maps.google.co.jp/maps?q=' + latlng + '&iwloc=J" target="_blank" rel="noopener noreferrer">Googleマップで見る</a></p></div>';
       //情報ウィンドウのインスタンスを生成
       var infowindow = new google.maps.InfoWindow({
         content: content,


### PR DESCRIPTION
Closes #93  

### 【概要】
・herokuへのpush時にエラーが出たため、map-show.jsのテンプレート構文による文字列中での変数展開を従前の書き方へ修正

### 【修正内容の検証方法】
`bin/rspec`
`bundle exec rubocop`

### 【この修正が正しい理由】
・テストが正常に完了する(203 examples, 0 failures)
・rubocopが正常に完了する(77 files inspected, no offenses detected)