### PR TITLE
docs:リポジトリ名をdate-matchに変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         environment:
           POSTGRES_PASSWORD: password
 
-    working_directory: ~/datelog
+    working_directory: ~/date-match
 
     steps:
       - checkout

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,16 +2,16 @@
 lock '3.14.1'
 
 # デプロイするアプリケーション名
-set :application, 'datelog'
+set :application, 'date-match'
 
 # cloneするgitのレポジトリ
-set :repo_url, 'git@github.com:sdkk1/datelog.git'
+set :repo_url, 'git@github.com:sdkk1/date-match.git'
 
 # deployするブランチ（デフォルトはmasterなのでなくても可）
 set :branch, 'master'
 
 # deploy先のディレクトリ
-set :deploy_to, '/var/www/rails/datelog'
+set :deploy_to, '/var/www/rails/date-match'
 
 # シンボリックリンクをはるファイル
 set :linked_files, fetch(:linked_files, []).push('config/settings.yml')

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -3,7 +3,7 @@
 # 何秒経過すればワーカーを削除するのかを決める
   $timeout = 30
 # 自分のアプリケーション名、currentがつくことに注意。
-  $app_dir = "/var/www/rails/datelog/current"
+  $app_dir = "/var/www/rails/date-match/current"
 # リクエストを受け取るポート番号を指定。後述
   $listen  = File.expand_path 'tmp/sockets/.unicorn.sock', $app_dir
 # PIDの管理ファイルディレクトリ


### PR DESCRIPTION
Closes #200 

### 【概要】
・リポジトリ名をdate-matchに変更

### 【修正内容の検証方法】
CircleCIによる自動テスト

### 【この修正が正しい理由】
・テストが正常に完了する(178 examples, 0 failures)
・rubocopが正常に完了する(88 files inspected, no offenses detected)